### PR TITLE
Potential fix for code scanning alert no. 13: Uncontrolled command line

### DIFF
--- a/scripts/bulk_add_dependabot_codeql.py
+++ b/scripts/bulk_add_dependabot_codeql.py
@@ -157,10 +157,28 @@ def require_gh() -> None:
 # Repo discovery (fixes your 404)
 # -----------------------------
 
+_OWNER_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$")
+_REPO_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _validate_owner(owner: str) -> str:
+    o = (owner or "").strip()
+    if not _OWNER_RE.fullmatch(o):
+        raise SystemExit(f"ERROR: Invalid owner value: {owner!r}")
+    return o
+
+
+def _validate_repo_name(repo: str) -> str:
+    r = (repo or "").strip()
+    if not r or r.startswith("-") or not _REPO_RE.fullmatch(r):
+        raise SystemExit(f"ERROR: Invalid repository name: {repo!r}")
+    return r
+
+
 def parse_repos_csv(arg: Optional[str]) -> Optional[Set[str]]:
     if not arg:
         return None
-    parts = [p.strip() for p in arg.split(",") if p.strip()]
+    parts = [_validate_repo_name(p.strip()) for p in arg.split(",") if p.strip()]
     return set(parts) if parts else None
 
 
@@ -1351,7 +1369,7 @@ def main() -> int:
 
     args = ap.parse_args()
 
-    owner = args.owner
+    owner = _validate_owner(args.owner)
     include = normalize_include(args.include)
 
     target_branch = args.branch or build_branch_name()


### PR DESCRIPTION
Potential fix for [https://github.com/Notoriousjayy/ghas-code-scanning-toolkit/security/code-scanning/13](https://github.com/Notoriousjayy/ghas-code-scanning-toolkit/security/code-scanning/13)

General fix approach: keep `subprocess.run([...])` (safe vs shell execution), but add strict allowlist validation for user-controlled CLI values before they are incorporated into command arguments.

Best targeted fix in `scripts/bulk_add_dependabot_codeql.py`:
1. Add a validation helper for GitHub owner/repo identifiers using a conservative regex (alphanumeric plus `-`, `_`, `.` as appropriate; no whitespace; must not start with `-`).
2. Validate `owner` immediately after `parse_args()` and before any `gh_*` calls.
3. (Optional but low-impact and robust) validate repo names parsed from `--repos` similarly in `parse_repos_csv`.

This preserves existing functionality for valid inputs while blocking malicious/ambiguous argument forms.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
