### PR TITLE
Potential fix for code scanning alert no. 13: Uncontrolled command line

### DIFF
--- a/scripts/bulk_add_dependabot_codeql.py
+++ b/scripts/bulk_add_dependabot_codeql.py
@@ -391,6 +391,26 @@ def put_file(
 
         raise
 
+def _validate_branch_name(branch: str) -> str:
+    b = (branch or "").strip()
+    if not b:
+        raise ValueError("Invalid branch name: empty")
+    if b.startswith("/") or b.endswith("/") or "//" in b:
+        raise ValueError(f"Invalid branch name: {branch}")
+    if ".." in b or "@{" in b or "\\" in b:
+        raise ValueError(f"Invalid branch name: {branch}")
+    if any(ord(ch) < 32 or ch.isspace() for ch in b):
+        raise ValueError(f"Invalid branch name: {branch}")
+    if any(ch in b for ch in ['~', '^', ':', '?', '*', '[']):
+        raise ValueError(f"Invalid branch name: {branch}")
+    if b.endswith(".") or b.endswith(".lock"):
+        raise ValueError(f"Invalid branch name: {branch}")
+    parts = b.split("/")
+    if any((not p) or p.startswith(".") for p in parts):
+        raise ValueError(f"Invalid branch name: {branch}")
+    return b
+
+
 def get_head_commit_sha(owner: str, repo: str, branch: str) -> str:
     j = gh_json(["api", f"repos/{owner}/{repo}/git/ref/heads/{branch}"])
     sha = (j or {}).get("object", {}).get("sha")
@@ -1372,7 +1392,7 @@ def main() -> int:
     owner = _validate_owner(args.owner)
     include = normalize_include(args.include)
 
-    target_branch = args.branch or build_branch_name()
+    target_branch = _validate_branch_name(args.branch) if args.branch else build_branch_name()
 
     require_gh()
 


### PR DESCRIPTION
Potential fix for [https://github.com/Notoriousjayy/ghas-code-scanning-toolkit/security/code-scanning/13](https://github.com/Notoriousjayy/ghas-code-scanning-toolkit/security/code-scanning/13)

To fix this safely without changing intended behavior, validate the optional user-provided `--branch` value against a strict Git ref branch-name policy **before** it is used to build `gh` command arguments. The best single fix is to add a dedicated validator (for branch names) and apply it when computing `target_branch`.

In `scripts/bulk_add_dependabot_codeql.py`:

- Add a helper function (near other validators, e.g., near `_validate_owner`) such as `_validate_branch_name(branch: str) -> str`.
- Enforce conservative Git branch rules:
  - non-empty
  - no leading/trailing `/`, no `//`
  - no `..`, no `@{`, no backslash
  - no whitespace/control chars
  - no forbidden chars `~ ^ : ? * [`
  - no segment starting with `.`
  - does not end with `.lock` or `.`
- Use this validator at the point where `target_branch` is assigned:
  - if `args.branch` is provided, validate it
  - otherwise keep existing generated branch behavior (`build_branch_name()`)

This keeps functionality the same for valid branch names while blocking malicious/invalid input before it reaches `subprocess.run`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
