### PR TITLE
Potential fix for code scanning alert no. 13: Uncontrolled command line

### DIFF
--- a/scripts/bulk_add_dependabot_codeql.py
+++ b/scripts/bulk_add_dependabot_codeql.py
@@ -93,9 +93,24 @@ def run_cmd(args: Sequence[str]) -> Tuple[int, str, str]:
     return p.returncode, p.stdout, p.stderr
 
 
+def _validate_gh_args(args: Sequence[str]) -> List[str]:
+    """Validate/sanitize argv-style `gh` arguments before execution."""
+    safe_args: List[str] = []
+    for a in args:
+        if not isinstance(a, str):
+            raise ValueError("Invalid gh argument: non-string value")
+        if "\x00" in a or any(ord(ch) < 32 for ch in a):
+            raise ValueError(f"Invalid gh argument (control chars): {a!r}")
+        # Conservative allowlist covering current usage (api paths, flags, form fields, refs).
+        if not re.fullmatch(r"[A-Za-z0-9._~:/=@,+\-]+", a):
+            raise ValueError(f"Invalid gh argument (disallowed chars): {a!r}")
+        safe_args.append(a)
+    return safe_args
+
+
 def gh_json(args: List[str], allow_not_found: bool = False, *, max_retries: int = 3, backoff_base: float = 0.75) -> Any:
     """Run `gh ...` and parse JSON, with basic retries on transient failures."""
-    cmd = ["gh"] + args
+    cmd = ["gh"] + _validate_gh_args(args)
 
     for attempt in range(max_retries + 1):
         rc, out, err = run_cmd(cmd)


### PR DESCRIPTION
Potential fix for [https://github.com/Notoriousjayy/ghas-code-scanning-toolkit/security/code-scanning/13](https://github.com/Notoriousjayy/ghas-code-scanning-toolkit/security/code-scanning/13)

General fix: enforce strict validation on all user-influenced command arguments before passing them to subprocess-backed execution. Prefer allowlist-style character constraints and reject suspicious flags/payloads.

Best single fix here (without changing behavior): add a centralized validator in `gh_json` that checks each `gh` argument segment before building `cmd`, and ensure branch input remains normalized through `_validate_branch_name` (already present). This preserves existing functionality while guaranteeing unsafe characters/patterns cannot reach command execution.

In `scripts/bulk_add_dependabot_codeql.py` around `gh_json` (lines ~96–99), add a helper `_validate_gh_args(args: Sequence[str]) -> List[str]` and call it instead of raw `args` when constructing `cmd`. The validator should:
- ensure each arg is a string and non-empty where required,
- reject null bytes and control characters,
- allow only a conservative character set used by current gh API/path/form args,
- return a sanitized copied list.

No new third-party dependencies are required; `re` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
