### PR TITLE
Potential fix for code scanning alert no. 13: Uncontrolled command line

### DIFF
--- a/scripts/bulk_add_dependabot_codeql.py
+++ b/scripts/bulk_add_dependabot_codeql.py
@@ -151,11 +151,12 @@ def gh_json(args: List[str], allow_not_found: bool = False, *, max_retries: int 
 
     raise RuntimeError(f"gh command failed (exhausted retries): {' '.join(cmd)}")
 def gh_text(args: List[str], allow_not_found: bool = False) -> Optional[str]:
-    rc, out, err = run_cmd(["gh"] + args)
+    safe_args = _validate_gh_args(args)
+    rc, out, err = run_cmd(["gh"] + safe_args)
     if rc != 0:
         if allow_not_found and ("404" in err or "Not Found" in err):
             return None
-        raise RuntimeError(f"gh command failed ({rc}): gh {' '.join(args)}\n{err.strip()}")
+        raise RuntimeError(f"gh command failed ({rc}): gh {' '.join(safe_args)}\n{err.strip()}")
     return out
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/Notoriousjayy/ghas-code-scanning-toolkit/security/code-scanning/13](https://github.com/Notoriousjayy/ghas-code-scanning-toolkit/security/code-scanning/13)

General fix: ensure all `gh` subprocess invocations pass through a single strict argument validator before execution, so user-influenced values cannot introduce unsafe flags/options or malformed arguments.

Best targeted fix without changing intended behavior: in `scripts/bulk_add_dependabot_codeql.py`, update `gh_text` to mirror `gh_json` by calling `_validate_gh_args(args)` before building the command list. This keeps existing functionality, preserves use of `subprocess.run(..., shell=False)`, and closes the inconsistent validation path that CodeQL traced.

Specific change needed:
- File: `scripts/bulk_add_dependabot_codeql.py`
- Region: function `gh_text(...)` around current lines 153–159
- Replace `run_cmd(["gh"] + args)` with validation then `run_cmd(["gh"] + safe_args)`.
- Also use `safe_args` in the error message to avoid reflecting unvalidated argv.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
