### PR TITLE
Potential fix for code scanning alert no. 13: Uncontrolled command line

### DIFF
--- a/scripts/bulk_add_dependabot_codeql.py
+++ b/scripts/bulk_add_dependabot_codeql.py
@@ -417,6 +417,8 @@ def _validate_branch_name(branch: str) -> str:
     b = (branch or "").strip()
     if not b:
         raise ValueError("Invalid branch name: empty")
+    if len(b) > 255:
+        raise ValueError(f"Invalid branch name: {branch}")
     if b.startswith("/") or b.endswith("/") or "//" in b:
         raise ValueError(f"Invalid branch name: {branch}")
     if ".." in b or "@{" in b or "\\" in b:
@@ -424,6 +426,8 @@ def _validate_branch_name(branch: str) -> str:
     if any(ord(ch) < 32 or ch.isspace() for ch in b):
         raise ValueError(f"Invalid branch name: {branch}")
     if any(ch in b for ch in ['~', '^', ':', '?', '*', '[']):
+        raise ValueError(f"Invalid branch name: {branch}")
+    if not re.fullmatch(r"[A-Za-z0-9._/-]+", b):
         raise ValueError(f"Invalid branch name: {branch}")
     if b.endswith(".") or b.endswith(".lock"):
         raise ValueError(f"Invalid branch name: {branch}")

--- a/scripts/bulk_add_dependabot_codeql.py
+++ b/scripts/bulk_add_dependabot_codeql.py
@@ -89,7 +89,13 @@ def _sleep_backoff(attempt: int, base: float) -> None:
 
 
 def run_cmd(args: Sequence[str]) -> Tuple[int, str, str]:
-    p = subprocess.run(list(args), capture_output=True, text=True)
+    argv = list(args)
+    if not argv:
+        raise ValueError("Invalid command: empty argv")
+    if argv[0] != "gh":
+        raise ValueError(f"Invalid command: only 'gh' is allowed, got {argv[0]!r}")
+    safe_argv = ["gh"] + _validate_gh_args(argv[1:])
+    p = subprocess.run(safe_argv, capture_output=True, text=True)
     return p.returncode, p.stdout, p.stderr
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/Notoriousjayy/ghas-code-scanning-toolkit/security/code-scanning/13](https://github.com/Notoriousjayy/ghas-code-scanning-toolkit/security/code-scanning/13)

Best fix: make `run_cmd` a **gh-only executor** that enforces the command binary and re-validates arguments before calling `subprocess.run`. This preserves behavior while making the sink itself safe and explicit, which also addresses taint-analysis concerns.

Concretely in `scripts/bulk_add_dependabot_codeql.py`:
- Update `run_cmd` (lines around 91–93) to:
  - reject empty commands;
  - require first arg to be exactly `"gh"`;
  - validate remaining args with `_validate_gh_args`;
  - execute only `["gh", *validated_args]`.
- Keep existing call sites unchanged (`gh_json` already constructs `["gh"] + ...`), so no functional change beyond stronger enforcement.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
