### PR TITLE
Potential fix for code scanning alert no. 14: Uncontrolled command line

### DIFF
--- a/scripts/bulk_add_dependabot_codeql.py
+++ b/scripts/bulk_add_dependabot_codeql.py
@@ -448,8 +448,9 @@ def get_head_commit_sha(owner: str, repo: str, branch: str) -> str:
 def create_branch(owner: str, repo: str, new_branch: str, base_branch: str, dry_run: bool) -> None:
     base_sha = get_head_commit_sha(owner, repo, base_branch)
 
-    existing = gh_json(["api", f"repos/{owner}/{repo}/git/ref/heads/{new_branch}"], allow_not_found=True)
-    if existing:
+    refs = gh_json(["api", f"repos/{owner}/{repo}/git/matching-refs/heads/"], allow_not_found=True) or []
+    wanted_ref = f"refs/heads/{new_branch}"
+    if any((ref or {}).get("ref") == wanted_ref for ref in refs):
         return
 
     if dry_run:


### PR DESCRIPTION
Potential fix for [https://github.com/Notoriousjayy/ghas-code-scanning-toolkit/security/code-scanning/14](https://github.com/Notoriousjayy/ghas-code-scanning-toolkit/security/code-scanning/14)

General fix: prevent user-controlled values from being embedded in command arguments that reach process execution, especially in path-like CLI arguments. Prefer hardcoded/safe-selected literals where possible.

Best targeted fix without changing intended functionality: in `create_branch`, stop querying branch existence via the user-selected `new_branch` path (`repos/.../git/ref/heads/{new_branch}`), and instead query refs via a fixed endpoint and locally compare names. This keeps behavior (skip if branch exists) while removing tainted input from the executed argument list.

In `scripts/bulk_add_dependabot_codeql.py`:
- Edit `create_branch(...)` around the current `existing = gh_json(["api", f"repos/{owner}/{repo}/git/ref/heads/{new_branch}"], ...)`.
- Replace with:
  - call to hardcoded endpoint `repos/{owner}/{repo}/git/matching-refs/heads/`
  - local Python check for exact `refs/heads/{new_branch}` match.
- No new imports/dependencies needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
